### PR TITLE
Add link to saltstack formula

### DIFF
--- a/content/doc/integrations.md
+++ b/content/doc/integrations.md
@@ -25,3 +25,5 @@ With configuration management systems:
     (Heavy Water Operations, LLC)
 -   [Puppet module](https://github.com/alphagov/puppet-aptly) by
     Government Digital Services
+-   [SaltStack Formula](https://github.com/saltstack-formulas/aptly-formula) by
+    Forrest Alvarez and Brian Jackson


### PR DESCRIPTION
This just adds a link to the integration page with the saltstack formula people can use.