### PR TITLE
Update links to Debian / Ubuntu packages for aptly

### DIFF
--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -10,7 +10,7 @@
       <div class="container">
         <img src="/img/os_icons/debian.png" alt="Debian/Ubuntu" class="pull-right">
         <h2>aptly installation</h2>
-        <p><b>Debian/Ubuntu</b>: aptly package is <a href="https://packages.debian.org/jessie/aptly">available</a> in Debian jessie (testing). If you would like to install aptly on older versions of Debian or to stay on the bleeding edge, aptly could be installed
+        <p><b>Debian/Ubuntu</b>: aptly package is available in <a href="https://packages.debian.org/search?searchon=names&keywords=aptly">Debian </a> as well as <a href="http://packages.ubuntu.com/search?suite=all&searchon=names&keywords=aptly">Ubuntu</a>. If you would like to install aptly on older versions of Debian / Ubuntu or to stay on the bleeding edge, aptly could be installed
         by adding new repository to    <code>/etc/apt/sources.list</code>:</p>
         <pre>deb http://repo.aptly.info/ squeeze main</pre>
         <p>And importing key that is used to sign the release either from keys.gnupg.net:</p>


### PR DESCRIPTION
This pull request updates the links to the various Debian and Ubuntu packages for aptly available in the official repositories.

current aptly versions:
Debian:
 *   jessie (stable) 0.8-3
 *   stretch (testing) 0.9.7-1
 *   sid (unstable) 0.9.7-1

Ubuntu:
*    xenial (16.04LTS) 0.9.6-1
*    yakkety (16.10) 0.9.7-1
*    zesty 0.9.7-1