### PR TITLE
Added command line option -skip-existing-packages to the mirror update description.

### DIFF
--- a/content/doc/aptly/mirror/update.md
+++ b/content/doc/aptly/mirror/update.md
@@ -40,6 +40,8 @@ Flags:
 -   `-keyring=trustedkeys.gpg` gpg keyring to use when verifying Release
     file (could be specified multiple times)
 -   `-max-tries=1`: Max download tries till process fails with download error
+-   `-skip-existing-packages=false`: do not check file existence for packages
+    listed in the internal database of the mirror
 
 While updating mirror, aptly would verify signature of `Release` file
 using GnuPG. Please read information about signature verification in


### PR DESCRIPTION
Corresponding to https://github.com/smira/aptly/pull/520 