### PR TITLE
Add my Python API client library to the integrations page

### DIFF
--- a/content/doc/integrations.md
+++ b/content/doc/integrations.md
@@ -29,6 +29,8 @@ With configuration management systems:
 -   [SaltStack Formula](https://github.com/saltstack-formulas/aptly-formula) by
     Forrest Alvarez and Brian Jackson
 
-CLI for aptly API:
+aptly API:
 
--   [Ruby aptly CLI/library](https://github.com/sepulworld/aptly_cli) by Zane Williamson
+-   [aptly_cli Ruby library](https://github.com/sepulworld/aptly_cli) by Zane Williamson. 
+    This includes an aptly API command-line client.
+-   [aptly-api-client Python library](https://github.com/gopythongo/aptly-api-client) by Jonas Maurus.


### PR DESCRIPTION
[aptly-api-client](https://github.com/gopythongo/aptly-api-client/) is a pythonic low-level abstraction over the aptly API.