### PR TITLE
also document NotAutomatic and ButAutomaticUpgrades as publish params

### DIFF
--- a/content/doc/api/publish.md
+++ b/content/doc/api/publish.md
@@ -76,6 +76,8 @@ JSON body params:
  `ForceOverwrite`          | bool                 | when publishing, overwrite files in `pool/` directory without notice
  `Architectures`           | []string             | override list of published architectures
  `Signing`                 | SigningOptions       | gpg options (see above)
+ `NotAutomatic`            | string               | setting to `yes` indicates to the package manager to not install or upgrade packages from the repository without user consent [🛈](https://wiki.debian.org/DebianRepository/Format#NotAutomatic_and_ButAutomaticUpgrades)
+ `ButAutomaticUpgrades`    | string               | setting to `yes` excludes upgrades from the `NotAutomic` setting [🛈](https://wiki.debian.org/DebianRepository/Format#NotAutomatic_and_ButAutomaticUpgrades)
 
 Notes on `Sources` field:
 


### PR DESCRIPTION
follow up to 395d7440296912813022ec6e5cfa8de47ffe417e where I only added
them to the object properties while in fact they are also parameters for
the actual publish call (which is where the properties are set)

:cry: 