### PR TITLE
Fix `aptly api serve` docs

### DIFF
--- a/content/doc/api.md
+++ b/content/doc/api.md
@@ -33,6 +33,18 @@ Run `aptly api serve` to start HTTP service:
 
 By default aptly would listen on `:8080`, but it could be changed with `-listen` flag.
 
+Usage:
+
+    $ aptly api serve -listen=:8080
+
+Flags:
+
+-   `-listen=":8080"`: host:port for HTTP listening
+-   `-no-lock`: don't lock the database
+
+When `-no-lock` option is enabled, API server acquires and drops the lock
+around all the operations, so that API and CLI could be used concurrently.
+
 Try some APIs:
 
     $ curl http://localhost:8080/api/version

--- a/content/doc/aptly/serve.md
+++ b/content/doc/aptly/serve.md
@@ -20,9 +20,6 @@ root that contains published repositories. aptly would print recommended
 `apt-sources` for the currently published repositories. By default aptly
 would listen on port 8080, but this can be changed with flag `-listen`.
 
-When `-no-lock` option is enabled, API server acquires and drops the lock
-around all the operations, so that API and CLI could be used concurrently.
-
 Usage:
 
     $ aptly serve -listen=:8080
@@ -30,7 +27,6 @@ Usage:
 Flags:
 
 -   `-listen=":8080"`: host:port for HTTP listening
--   `-no-lock`: don't lock the database
 
 Example:
 


### PR DESCRIPTION
They got mixed up with `aptly serve` docs.

See smira/aptly#700