### PR TITLE
Remove 'upcoming features' section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -147,31 +147,6 @@
           </div>
         </div>
         <hr>
-        <p class="text-center">
-          <a class="more-features" href="#">See upcoming features<i class="glyphicon glyphicon-chevron-down"></i></a>
-        </p>
-        <div id="upcoming" class="hidden">
-          <div class="row">
-            <div class="col-md-6">
-              <div class="feature-wrapper">
-                <span class="feature-icon feature-icon-api"></span>
-                <div class="feature-text">
-                  <h4>Mirror repositories as-is. </h4>
-                  <p>Mirror official Debian repositories (as snapshots) without resigning by your own key. </p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6">
-              <div class="feature-wrapper">
-                <i class="feature-icon feature-icon-as-is"></i>
-                <div class="feature-text">
-                  <h4>RPM support</h4>
-                  <p>Support for yum repositories, mirroring, snapshots, local repos, publishing, searching, ...</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </section>
     <section class="promo-trusted">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
       <div class="container">
         {{ template "partials/nav.html" . }}
         <div class="copy">
-          Sponsored by <a href="http://express42.com/">express42</a>  &copy;&nbsp;2013-2016  Andrey Smirnov
+          Sponsored by <a href="http://express42.com/">express42</a>  &copy;&nbsp;2013-2018 aptly contributors
         </div>
       </div>
     </footer>


### PR DESCRIPTION
This section was mentioning features we're most probably won't be
working in the nearest future.

Also update footer copyright.